### PR TITLE
Improved @Test testSerialization() to highlight a serialization bug, …

### DIFF
--- a/tests/marauroa/common/game/RPObjectTest.java
+++ b/tests/marauroa/common/game/RPObjectTest.java
@@ -199,10 +199,18 @@ public class RPObjectTest {
 
 		assertEquals(obj, result);
 
-		RPSlot inslot = result.getSlot("lhand");
-		for ( RPObject contained : inslot) {
+		RPSlot lHandBeforeSerialization = obj.getSlot("lhand");
+		RPSlot lHandAfterSerialization = result.getSlot("lhand");
+		for ( RPObject contained : lHandAfterSerialization) {
 			assertTrue(contained.isContained());
 		}
+
+		RPObject secondPocket1 = new RPObject();
+		RPObject secondPocket2 = new RPObject();
+		lHandBeforeSerialization.add(secondPocket1);
+		lHandAfterSerialization.add(secondPocket2);
+
+		assertEquals(secondPocket1.getID(), secondPocket2.getID());
 	}
 
 	/**


### PR DESCRIPTION
…which caused RPSlot to assign conflicting ids during rpSlot.add().

Improved testSerialization test.

This test improvement shows a current bug.

Steps to reproduce:
1) Serialize RPObject with an RPSlot with objects.
2) Deserialize it.
3) Add something to the deserialized object's RPSlot.

RPSlot will always assign id 0 to the new object, which will make this slot contain few objects with id 0.
SlotOwner should serialize lastAssignedId.

Pls look into it:) appreciated.
If have no time, don't merge this request, I'll fix it on Wednesday and commit into this PR.