### PR TITLE
Added a test to verify id assigning mechanism (ids must be unique) af…

### DIFF
--- a/src/marauroa/common/game/SlotOwner.java
+++ b/src/marauroa/common/game/SlotOwner.java
@@ -359,6 +359,37 @@ public abstract class SlotOwner extends Attributes {
 				slots.add(slot);
 			}
 		}
+		//We get root owner because RPSlot of any depth uses root's lastAssignedId
+		SlotOwner rootOwner = this;
+		while (rootOwner.getContainerOwner() != null) {
+			rootOwner = rootOwner.getContainerOwner();
+		}
+		rootOwner.lastAssignedID = getHighestId(rootOwner) + 1;
+	}
+
+	/**
+	 * Recursively goes from rootOwner through all objects
+	 * down in the tree and gets highest object ID.
+	 * @param rootOwner slotOwner from which we start moving down.
+	 * @return highest object id.
+	 */
+	private int getHighestId(SlotOwner rootOwner) {
+		int highestId = 0;
+		if (rootOwner.slots == null) {
+			return highestId;
+		}
+		for (RPSlot slot : rootOwner.slots) {
+			for (RPObject object : slot) {
+				int objectId = object.getID().getObjectID();
+				if (highestId < objectId) {
+					highestId = objectId;
+				}
+				if (object.slots != null && object.slots.size() != 0) {
+					highestId = Math.max(highestId, getHighestId(object));
+				}
+			}
+		}
+		return highestId;
 	}
 
 	@Override

--- a/tests/marauroa/common/game/RPObjectTest.java
+++ b/tests/marauroa/common/game/RPObjectTest.java
@@ -203,6 +203,16 @@ public class RPObjectTest {
 		for ( RPObject contained : inslot) {
 			assertTrue(contained.isContained());
 		}
+		inslot.add(new RPObject());
+
+		for (RPObject object : inslot) {
+			for (RPObject object1 : inslot) {
+				if (object == object1) continue; //Skip check against itself
+				if (object.getID().getObjectID() == object1.getID().getObjectID()) {
+					fail("Object IDs must be unique.");
+				}
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
…ter serialization->deserialization. Fixed bug with lastAssignedId being 0 after deserialization, which caused similar ids in RPSlot.

Fixed a bug, where after deserialization lastAssignedId was 0.
This caused id collision, which could lead to dangerous behavior, e.g. where you remove one object with id 5, but another object is removed, because another object also has id 5.
Also added a test to test object ids.